### PR TITLE
Join component

### DIFF
--- a/src/components/Dataset/Join.tsx
+++ b/src/components/Dataset/Join.tsx
@@ -1,0 +1,14 @@
+export type joinTypeType = 'left' | 'right' | 'full' | 'inner'
+
+interface IJoinProps {
+   joinKey : string | [string, string]
+   dataset: string
+   joinType?: joinTypeType
+}
+/*
+* Les props sont utilisées dans le Dataset parent pour appliquer la jointure
+*/
+export const Join:React.FC<IJoinProps> = () => {
+    return <></>
+
+}

--- a/src/components/Dataset/README.md
+++ b/src/components/Dataset/README.md
@@ -51,7 +51,41 @@ Cette opération est effectués côté client, et **ne modifie donc pas la requ�
 </Dashboard>
 ```
 
+## Join
 
+`Join` permet de faire une jointure avec un autre jeu de données. 
+L'ordre avec les composants `Transform` est respecté. Ainsi, un `Transform` placé **après** une jointure
+s'appliquera sur le produit de la jointure.
+
+- `dataset` : identifiant du dataset à joindre (= table de droite)
+- `joinKey` : un tableau avec les champs à joindre (ex : `['leftKey','RightKey]`)
+- `joinType` : type de jointure  `right` | `left` | `full` | `inner` (défaut `inner`)
+
+```jsx
+<Dashboard>
+      <Dataset
+        id="ref_epci_odema"
+        resource='odema:territoire_epci'
+        url='https://www.geo2france.fr/geoserver/ows'
+        type='wfs'
+        pageSize={1000}
+      >
+         <Filter field='annee'>{useControl('annee')}</Filter>
+      </Dataset>
+
+      <Dataset 
+        id="sinoe_synthese_indic" 
+        resource='sinoe59-indic-synth-acteur/lines'
+        url="https://data.ademe.fr/data-fair/api/v1/datasets"
+        type='datafair'
+        pageSize={5000}>
+            <Filter field='l_region'>Hauts-de-France</Filter>
+            <Filter field='annee'>{useControl('annee')}</Filter>
+            <Join dataset="ref_epci_odema" joinKey={["c_acteur","c_acteur_sinoe" ]} />
+            <Transform>SELECT c_acteur, name_short as nom, tonnage_omr, tonnage_bio FROM ?</Transform>
+      </Dataset>
+</Dashboard>
+```
 
 ## Filter
 

--- a/src/dsl/index.ts
+++ b/src/dsl/index.ts
@@ -14,12 +14,14 @@ import { Select } from "../components/Control/Select"
 import { Input } from "antd";
 import { Palette, usePalette, PalettePreview } from "../components/Palette/Palette";
 import { Debug } from "../components/Debug/Debug";
+import { Join } from "../components/Dataset/Join";
 
 export {
     Dashboard,
     Dataset,
     Provider,
     Transform,
+    Join,
     Filter,
     DataPreview,
     ChartPie,


### PR DESCRIPTION
Composant `Join` permettant de faire une jointure avec un autre jeu de données.
Différents type de jointures sont supportés (left, right, inner, full).

```jsx
<Dashboard>
      <Dataset
        id="ref_epci_odema"
        resource='odema:territoire_epci'
        url='https://www.geo2france.fr/geoserver/ows'
        type='wfs'
        pageSize={1000}
      >
         <Filter field='annee'>{useControl('annee')}</Filter>
      </Dataset>

      <Dataset 
        id="sinoe_synthese_indic" 
        resource='sinoe59-indic-synth-acteur/lines'
        url="https://data.ademe.fr/data-fair/api/v1/datasets"
        type='datafair'
        pageSize={5000}>
            <Filter field='l_region'>Hauts-de-France</Filter>
            <Filter field='annee'>{useControl('annee')}</Filter>
            <Join dataset="ref_epci_odema" joinKey={["c_acteur","c_acteur_sinoe" ]} />
            <Transform>SELECT c_acteur, name_short as nom, tonnage_omr, tonnage_bio FROM ?</Transform>
      </Dataset>
</Dashboard>
```