### PR TITLE
Composant ChartEcharts

### DIFF
--- a/src/components/Charts/ChartEcharts.tsx
+++ b/src/components/Charts/ChartEcharts.tsx
@@ -1,0 +1,51 @@
+import { forwardRef, useImperativeHandle, useRef } from 'react';
+import { theme } from 'antd';
+import { EChartsOption } from "echarts"
+import EChartsReact from "echarts-for-react"
+import { usePalette } from "../Palette/Palette"
+import deepMerge from "../../utils/deepmerge"
+
+const { useToken } = theme;
+
+
+interface ChartEchartsProps {
+    option?:EChartsOption,
+}
+
+/*
+* Ce composant peut servir de base aux développements d'autres composants ou être utilisé directement dans une page (non conseillé).
+* - Applique la palette utilisateur
+* - Utilise le style de texte de l'application
+* devnote : A partir de React 19, ne plus utiliser forwardRef https://react.dev/reference/react/forwardRef
+*/
+
+export const ChartEcharts = forwardRef<EChartsReact, ChartEchartsProps>(({ option = {} }, ref) =>  {
+    const innerRef = useRef<EChartsReact>(null)
+    useImperativeHandle(ref, () => innerRef.current as EChartsReact, []) // Pour exposer le innerref au parent
+
+    const { token } = useToken();
+
+    const n_series = Array.isArray(option.series) ? option.series?.length : 1
+
+    // Récupérer et traduire les éléments depuis le theme antdesign : police, couleurs, etc..
+    // Ceci peut-être surchargé par les options de l'utilisateur
+    const default_option: Partial<EChartsOption> = {
+        color: usePalette({nColors:n_series}),
+        textStyle: {
+             fontFamily : token.fontFamily,
+             color: token.colorTextSecondary
+        },
+        xAxis: {
+            axisLine: { lineStyle: { color:  token.colorTextSecondary } },
+          },
+        yAxis: {
+            axisLine: { lineStyle: { color: token.colorTextSecondary } },
+        },
+    }
+    return (
+        <EChartsReact 
+            option={ deepMerge({}, default_option, option) } 
+            ref={innerRef}
+        />
+    )
+})

--- a/src/components/Charts/YearSerie.tsx
+++ b/src/components/Charts/YearSerie.tsx
@@ -7,8 +7,9 @@ import { from, op } from "arquero"
 import { useDataset } from "../Dataset/hooks"
 import { SimpleRecord } from "../../types"
 import { EChartsOption } from "echarts"
-import EChartsReact from "echarts-for-react"
+//import EChartsReact from "echarts-for-react"
 import { usePalette } from "../Palette/Palette"
+import { ChartEcharts } from "./ChartEcharts"
 
 interface IYearSerieProps {
     dataset:string
@@ -83,21 +84,16 @@ export const ChartYearSerie:React.FC<IYearSerieProps> = ({dataset:dataset_id, ca
             trigger: 'axis',
             formatter: tooltipFormatter
           },
-        xAxis: [
-            {
-                type: 'time'
-            }
-        ],
-        yAxis: [
-            {
-                type: 'value',
-            }
-        ],
-       
+        xAxis: {
+            type: 'time',
+        },
+        yAxis:  {
+            type: 'value',
+        },
     }
      
     return (
-        <EChartsReact option={option}/>
+        <ChartEcharts option={option}/>
 
     )
 

--- a/src/dsl/index.ts
+++ b/src/dsl/index.ts
@@ -15,6 +15,7 @@ import { Input } from "antd";
 import { Palette, usePalette, PalettePreview } from "../components/Palette/Palette";
 import { Debug } from "../components/Debug/Debug";
 import { Join } from "../components/Dataset/Join";
+import { ChartEcharts } from "../components/Charts/ChartEcharts";
 
 export {
     Dashboard,
@@ -24,6 +25,7 @@ export {
     Join,
     Filter,
     DataPreview,
+    ChartEcharts,
     ChartPie,
     ChartYearSerie,
     useDataset,


### PR DESCRIPTION
Composant `ChartEcharts` destiné à être utilisé comme base pour la création d'un graphique custom.
Il peut aussi être utilisé directement dans une page (en lui passant les options attendus par un echarts).

Il permet de rendre un graphique eCharts en lui ajoutant des options par défaut : 
- Palette utilisateur (usePalette)
- Token Antdesign (fontFamily et fontColor)

Le mapping entre les token antDesign et les thème Echarts pourra être plus poussé.