### PR TITLE
Feature/annotation statistics card #106

### DIFF
--- a/docs/usage/dataviz.md
+++ b/docs/usage/dataviz.md
@@ -114,7 +114,7 @@ Lorsque annotation est une fonction, elle reçoit comme paramètre un objet qui 
 L'objet reçu en parmètre a les propriétés suivantes :
 
  - `value`: valeur courante affichée sur la carte
- - `compare_value` : valeur de comparaison
+ - `compareValue` : valeur de comparaison
  - `data` : tableau complet des données du dataset
 
 
@@ -135,7 +135,7 @@ L'objet reçu en parmètre a les propriétés suivantes :
 
         <Statistics 
           dataset="mondataset" dataKey="prix" unit="€" color="yellow" 
-           annotation={(p) => <span><b>🤡 {p.value.toLocaleString()} </b> ! Avant c'était plutôt <i>{p.compare_value.toLocaleString()}</i> ! </span>}
+           annotation={(p) => <span><b>🤡 {p.value.toLocaleString()} </b> ! Avant c'était plutôt <i>{p.compareValue.toLocaleString()}</i> ! </span>}
         />
 
     </StatisticsCollection>

--- a/src/components/Charts/Statistics.tsx
+++ b/src/components/Charts/Statistics.tsx
@@ -11,9 +11,14 @@ const { Text, Paragraph} = Typography;
 type comparwithType = "first" | "previous"
 
 interface annotation_params_type {
+    /** Valeur principale */
     value: number ;
+
+    /** Jeu de données utilisé */
     data: SimpleRecord[] | undefined;
-    compare_value: number ;
+
+    /** Valeur de comparaison */
+    compareValue: number ;
 }
 
 interface StatisticsProps {
@@ -97,7 +102,7 @@ export const Statistics: React.FC<StatisticsProps> = ({
 
     const tooltip =  help && <Tooltip title={help}><QuestionCircleOutlined /></Tooltip>
 
-    const annotation_params:annotation_params_type = {value: value || NaN, compare_value: compare_value || NaN, data:dataset?.data || [] }
+    const annotation_params:annotation_params_type = {value: value || NaN, compareValue: compare_value || NaN, data:dataset?.data || [] }
 
     let subtitle
 


### PR DESCRIPTION
Ajoute une propriété `annotation` sur `<Statistics>` afin de personnaliser le texte sous la valeur principale.
<img width="251" height="111" alt="image" src="https://github.com/user-attachments/assets/40a51ad0-8dba-4600-94ec-c5bd5beaa2be" />
