### PR TITLE
Personnalisation popup map

### DIFF
--- a/docs/usage/map.md
+++ b/docs/usage/map.md
@@ -16,7 +16,7 @@
 | `xKey`     | `number`        |        |           | Colonne contenant la coordonnée x (longitude)  |
 | `yKey`     | `number`        |        |           | Colonne contenant la coordonnée y (latitude)  |
 | `popup`     | `bool`        |        |           | Afficher une popup au clique sur une entité |
-| `popupFormatter`   | `function`    |        |    | Personnaliser le contenu de la popup (exemple : `(p) =>  <span>Valeur principale : {p.value}, autre valeur {p.row.area_code}</span>` )|
+| `popupFormatter`   | `function`    |        |    | Personnaliser le contenu de la popup (exemple : `(p) =>  <span>Code : <b>{p.area_code}</b>, Nom {p.name}</span>` )|
 
 Si le dataset provient d'un flux WFS, la géométrie est automatiquement utilisée. Sinon il faut renseigner les propriétés _xKey_ et _yKey_.
 

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -45,11 +45,6 @@ const build_geojson = (params: {
 }
 
 
-interface popupFormatterParam  {
-    row : SimpleRecord
-    value: number | string
-}
-
 /**
  * Une carto simple avec un layer
  * 
@@ -60,7 +55,7 @@ interface MapProps extends MapLayerProps {
   popup?: boolean;
 
   /** Fonction callback permettant de définir le contenu de la popup */
-  popupFormatter?: ((param: popupFormatterParam) => React.ReactNode);
+  popupFormatter?: ((param: SimpleRecord) => React.ReactNode);
 
   /** Titre du graphique */
   title?: string;
@@ -79,9 +74,9 @@ export const Map:React.FC<MapProps> = ({dataset, color, type, paint, categoryKey
        setClickedFeature({...evt.features[0], ...{lngLat:evt.lngLat}})
     }
 
-    const callbackParams:popupFormatterParam = {row: clickedFeature?.properties, value:categoryKey ? clickedFeature?.properties?.[categoryKey] : undefined }
+    const current_row = clickedFeature?.properties
 
-    const popupFormatter = popupFormatterUser || ((p:popupFormatterParam) => categoryKey ? p.row?.[categoryKey] : undefined)
+    const popupFormatter = popupFormatterUser || ((row:SimpleRecord) => categoryKey ? row?.[categoryKey] : undefined)
 
     const onMouseMoveMap = (evt:any) => {
         if (!mapRef.current) {
@@ -112,7 +107,7 @@ export const Map:React.FC<MapProps> = ({dataset, color, type, paint, categoryKey
                 <Popup longitude={clickedFeature.lngLat.lng} 
                         latitude={clickedFeature.lngLat.lat} 
                         onClose={() => {setClickedFeature(null)} }>
-                    <div>{ popupFormatter(callbackParams) || clickedFeature?.properties[categoryKey] }</div>
+                    <div>{ popupFormatter(current_row) || clickedFeature?.properties[categoryKey] }</div>
                 </Popup> 
             }
 


### PR DESCRIPTION
Ajout d'un fonction pour personnaliser le contenu de la popup de la carte.

exemple : 
```tsx
   <Map 
      title={`Périmètre d'étude de l'Aire Éducative`}
      dataset="infos_ae"
      categoryKey="area_name"
      popup
      popupFormatter={ r =>  <span>Code : <b>{r.area_code}</b></span>}
    />
```