### PR TITLE
Feat/chart year serie #153

### DIFF
--- a/src/components/Charts/YearSerie.tsx
+++ b/src/components/Charts/YearSerie.tsx
@@ -22,11 +22,21 @@ interface IYearSerieProps {
     stack?: boolean
     yearMark?:number | string
     normalize?:boolean
+
+    /**
+     * Fonction de tri appliquée aux séries (SeriesOption) avant affichage.
+     * Passée directement à `Array.sort()`.
+     *
+     * @example
+     * // Tri alphabétique des séries par leur nom
+     * seriesSort: (a, b) => a.name.localeCompare(b.name)
+     */
+    seriesSort? : (a: SeriesOption, b: SeriesOption) => number;
     type?: 'bar' | 'line' | 'area'
     /* Options Echarts addtionnelles */
     options?:Partial<EChartsOption>
 }
-export const ChartYearSerie:React.FC<IYearSerieProps> = ({dataset:dataset_id, categoryKey, valueKey, secondaryValueKey, yearKey, yearMark, stack:stack_input, title, type:chart_type='bar', normalize=false, options:custom_options={}}) => {
+export const ChartYearSerie:React.FC<IYearSerieProps> = ({dataset:dataset_id, categoryKey, valueKey, secondaryValueKey, yearKey, yearMark, stack:stack_input, title, type:chart_type='bar', normalize=false, seriesSort, options:custom_options={}}) => {
     const stack = stack_input || chart_type == 'line' ? false : true ; // Pas de stack par défaut pour le type line
     const dataset = useDataset(dataset_id)
     const data = dataset?.data
@@ -68,7 +78,7 @@ export const ChartYearSerie:React.FC<IYearSerieProps> = ({dataset:dataset_id, ca
             .rename({ value: valueKey, part: `${valueKey}_pct`, secondaryValue:secondaryValueKey || ''  }) // Rename to original var name
         ).objects()
     }
-    
+
     const COLORS = usePalette({nColors:distinct_cat?.length}) || []
     const colors_labels = usePaletteLabels() 
 
@@ -104,7 +114,7 @@ export const ChartYearSerie:React.FC<IYearSerieProps> = ({dataset:dataset_id, ca
             ]
           } : undefined,
         }
-    )) as SeriesOption[];
+    )).sort( seriesSort ) as SeriesOption[];
 
     function tooltipFormatter(params: any): string {
         if (!params || params.length === 0) return '';


### PR DESCRIPTION
#153 Evolutions sur ChartYearSerie : 

- Nouvelle propriété `options` :  permet de passer des options echarts (qui seront fusionnées avec celles générées par le composant) ()
- Nouvelle propriété `secondaryValueKey` : une colonne optionnelle avec une valeur secondaire. Celle-ci pourra être utilisée dans la personnalisation des tooltips (via la propriétés `options`)
- Nouvelle propriété `normalize` : pour afficher les données en % du total
- Nouvelle propriété `seriesSort` : fonction permettant de trier les séries (catégories).