### PR TITLE
Intro component #164

### DIFF
--- a/src/components/DashboardPage/Intro.tsx
+++ b/src/components/DashboardPage/Intro.tsx
@@ -1,0 +1,50 @@
+import { Icon } from "@iconify/react";
+import { FloatButton, Modal } from "antd"
+import { ReactElement, useState } from "react"
+
+interface IntroProps{
+    children:ReactElement
+
+    /** Titre de la modal */
+    title?:string
+}
+/**
+ * Texte introductif optionnel
+ * Modal accessible via un bouton flottant dans le coin supérieur droit
+ */
+export const Intro:React.FC<IntroProps> = ({children, title}) => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const showModal = () => {
+        setIsModalOpen(true);
+    };
+
+    const handleOk = () => {
+        setIsModalOpen(false);
+    };
+
+    const handleCancel = () => {
+        setIsModalOpen(false);
+    };
+    return (
+    <>
+        <FloatButton 
+            type="primary" 
+            onClick={showModal}
+            className="IntroButton"
+            style={{top:5, height:25}}
+            icon={<Icon icon={"fontisto:info"}/> } 
+            shape="square"
+            />
+        <Modal
+            title={title}
+            open={isModalOpen}
+            onOk={handleOk}
+            onCancel={handleCancel}
+            footer={null} 
+              width={{ xs: '100%', xl:'80%', xxl: '80%' }}>
+            {children}
+        </Modal>
+    </>
+    )
+}

--- a/src/components/DashboardPage/Page.tsx
+++ b/src/components/DashboardPage/Page.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_PALETTE, Palette, PaletteContext, PaletteType } from "../Palett
 import { Section, SectionProps } from "./Section";
 import { Icon } from "@iconify/react";
 import { DatasetRegistryContext } from "../Dataset/context";
+import { Intro } from "./Intro";
 
 const { Header } = Layout;
 
@@ -142,9 +143,12 @@ export const DSL_DashboardPage:React.FC<IDSLDashboardPageProps> = ({name = 'Tabl
 
     const logicalComponents:string[] = [Dataset.name, Provider.name, Palette.name, Debug.name]; //Composant logiques, a ne pas mettre dans la grid
 
-    const getComponentKind = (c:ReactElement) : "logical" | "control" | "other" | "section" => {
+    const getComponentKind = (c:ReactElement) : "logical" | "control" | "other" | "section" | "intro" => {
         if  (typeof(c.type) != 'string' &&  logicalComponents.includes(c.type.name)) {
             return "logical"
+        }
+        else if (typeof(c.type) != 'string' &&  c.type.name == Intro.name){
+            return "intro"
         }
         else if (typeof(c.type) != 'string' &&  c.type.name == DSL_Control.name){
             return "control"
@@ -161,6 +165,7 @@ export const DSL_DashboardPage:React.FC<IDSLDashboardPageProps> = ({name = 'Tabl
     const logic_components = childrenArray.filter((c) => getComponentKind(c) == 'logical');
     const control_components = childrenArray.filter((c) => getComponentKind(c) == 'control');
     const section_components = childrenArray.filter((c) => getComponentKind(c) == 'section') as React.ReactElement<SectionProps>[];
+    const intro_component = childrenArray.find((c) => getComponentKind(c) == 'intro') 
 
     if (debug && !logic_components.some((c) => typeof c.type !== "string" && c.type.name === Debug.name) ){
         logic_components.push(<Debug key="debug_property"/>);
@@ -213,6 +218,7 @@ export const DSL_DashboardPage:React.FC<IDSLDashboardPageProps> = ({name = 'Tabl
                         <div style={{margin:4}}> {items?.[0].children} </div>//Show content without tabs if only one
                     }
                 {logic_components}
+                {intro_component}
                 </PaletteContext.Provider>
     </>
 )}

--- a/src/components/Debug/Debug.tsx
+++ b/src/components/Debug/Debug.tsx
@@ -29,7 +29,12 @@ export const Debug:React.FC = () => {
         children: <DataPreview dataset={dataset.id} pageSize={3}/>
     }))
     return (<>
-        <FloatButton icon={<BugOutlined />} type="primary" onClick={() => setIsModalOpen(true)} style={{top:5}} className="debugFloatButton"/>
+        <FloatButton 
+            icon={<BugOutlined />} 
+            type="primary" 
+            onClick={() => setIsModalOpen(true)} 
+            style={{bottom:8, left: 8}} 
+            className="debugFloatButton"/>
         <Modal
             title="Information concepteur"
             width="90%"

--- a/src/dsl/index.ts
+++ b/src/dsl/index.ts
@@ -21,6 +21,7 @@ import { Statistics, StatisticsCollection } from "../components/Charts/Statistic
 import { MapLayer, Map } from "../components/Map/Map";
 import { Section } from "../components/DashboardPage/Section";
 import { LegendControl } from "../components/MapLegend/MapLegend";
+import { Intro } from "../components/DashboardPage/Intro";
 
 export {
     Dashboard,
@@ -30,6 +31,7 @@ export {
     Join,
     Filter,
     Section,
+    Intro,
     DataPreview,
     ChartEcharts,
     ChartPie,


### PR DESCRIPTION
Utiliser `<Intro>` pour définir un texte d'introduction. Supporte n'importe quel composant.

<img width="990" height="366" alt="image" src="https://github.com/user-attachments/assets/b2e11a30-5f94-4102-b4f8-170e110b3562" />
