### PR TITLE
Feat/element size

### DIFF
--- a/src/components/Charts/ChartComparison.tsx
+++ b/src/components/Charts/ChartComparison.tsx
@@ -5,10 +5,11 @@ import { SimpleRecord } from "../../types";
 import { from, op } from "arquero";
 import deepMerge from "../../utils/deepmerge";
 import { theme } from "antd";
+import { BaseChartProps } from "../DashboardPage/Block";
 
 type labelType = "percent" | "value" | "category" | "none" 
 
-export interface ChartComparisonProps {
+export interface ChartComparisonProps extends BaseChartProps  {
     /** Identifiant du dataset */
     dataset?:datasetInput;
 

--- a/src/components/Charts/ChartEvolution.tsx
+++ b/src/components/Charts/ChartEvolution.tsx
@@ -2,12 +2,12 @@ import { SimpleRecord } from "../../types";
 import { from, op } from "arquero";
 import deepMerge from "../../utils/deepmerge";
 import { EChartsOption, SeriesOption } from "echarts";
-import { useBlockConfig } from "../DashboardPage/Block";
+import { BaseChartProps, useBlockConfig } from "../DashboardPage/Block";
 import { ChartEcharts, useDataset } from "../../dsl";
 import { datasetInput } from "../Dataset/hooks";
 
 
-export interface ChartEvolutionProps {
+export interface ChartEvolutionProps extends BaseChartProps {
     /** Identifiant du dataset */
     dataset?:datasetInput;
 

--- a/src/components/Charts/Statistics.tsx
+++ b/src/components/Charts/Statistics.tsx
@@ -3,7 +3,7 @@ import { Avatar, Card, Col, Flex, Row, Tooltip, Typography } from "antd"
 import { Children, ReactElement } from "react";
 import { useDataset, datasetInput } from "../Dataset/hooks";
 import { Icon } from "@iconify/react";
-import { useBlockConfig } from "../DashboardPage/Block";
+import { BaseChartProps, useBlockConfig } from "../DashboardPage/Block";
 import { SimpleRecord } from "../../types";
 import { aggregator } from "../../utils/aggregator";
 import CountUp from "react-countup";
@@ -29,7 +29,7 @@ interface ICallbackParams {
     compareValue: number ;
 }
 
-export interface StatisticsProps {
+export interface StatisticsProps extends BaseChartProps {
     /** Identifiant du jeu de données ou tableau de valeurs */
     dataset:datasetInput, 
 
@@ -187,7 +187,7 @@ export const Statistics: React.FC<StatisticsProps> = ({
 }
 
 
-export interface StatisticsCollectionProps {
+export interface StatisticsCollectionProps extends BaseChartProps {
   /**
    * Un ou plusieurs composants `<Statistics>`.
    */

--- a/src/components/DashboardPage/Block.tsx
+++ b/src/components/DashboardPage/Block.tsx
@@ -7,14 +7,31 @@ import { MoreOutlined } from '@ant-design/icons';
 import { ErrorBoundary } from "../Layout/Error";
 import { useCardStyles } from "../../utils/cardStyles";
 import { useDataset } from "../../dsl";
+import { datasetInput } from "../Dataset/hooks";
 
 
 const { useToken } = theme;
 
+/**Propriétés de bases partagés par les block de dataviz */
+export interface BaseChartProps {
+  /** Identifiant du jeu de données, ou tableau de données */
+  dataset? : datasetInput
+
+  /** Titre du graphique. */
+  title?: string
+
+  /** Nombre  de colonnes occupées par le graphique.
+   * Peut être un nombre décimal. 
+   */
+  size?: number
+}
 
 export interface ChartBlockConfig {
     title?: string,
     dataExport?: SimpleRecord[]
+
+    /** Nombre de colonnes occupés par le block */
+    size?: number
 }
 type ChartBlockContextType = {
     config: ChartBlockConfig;

--- a/src/components/DashboardPage/Section.tsx
+++ b/src/components/DashboardPage/Section.tsx
@@ -22,11 +22,18 @@ export const Section: FC<SectionProps> = ({ children, columns=2 }) => {
   const childrenArray = Children.toArray(children).filter(isValidElement);
   return (
     <Row gutter={[8, 8]} style={{ margin: 0 }}>
-      {childrenArray.map((component, idx) => (
-        <Col xl={24 / columns} xs={24} key={idx}>
-          <DSL_ChartBlock>{component}</DSL_ChartBlock>
-        </Col>
-      ))}
+      {childrenArray.map((component, idx) => {
+        const size = isValidElement(component) && typeof (component.props as { size?: unknown }).size === "number" ? 
+            (component.props as { size?: number }).size! : 1;
+        const children_size =  Math.min(columns, size )
+        const span = Math.round( (24 / columns) * children_size )
+        
+        return (
+            <Col xl={ span } xs={24} key={idx}>
+              <DSL_ChartBlock>{component}</DSL_ChartBlock>
+            </Col>
+          )
+      })}
     </Row>
   );
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ export type { LegendItem } from "./components/MapLegend/MapLegend"
 export type { DashboardConfig } from "./components/Layout/DashboardApp"
 export type  { datasetInput } from "./components/Dataset/hooks";
 export type { PageProps } from "./components/Layout/DashboardApp";
+export type { BaseChartProps } from "./components/DashboardPage/Block";
 
 
 // DSL


### PR DESCRIPTION
Ajoute la possibilité de faire varier la largeur des graphiques. #198 
La nouvelle propriété `size` correspond aux nombres de colonne occupées par le graphique (peut être inférieur à 1). Par défaut, une page présente 2 colonnes, mais ceci peut être modifié au niveau de la page.

Dans l'exemple ci-dessous, la page a deux colonnes (défaut).
Premier graphique : `size={1.25}` 
deuxieme graphique :  `size={0.75}`
<img width="1624" height="739" alt="image" src="https://github.com/user-attachments/assets/7e141c20-2735-4e98-9249-564886c86274" />
