### PR TITLE
Use highlight

### DIFF
--- a/src/components/Charts/ChartEcharts.tsx
+++ b/src/components/Charts/ChartEcharts.tsx
@@ -15,7 +15,7 @@ export interface ChartEchartsProps extends EChartsReactProps {
 
 /**
 * Ce composant peut servir de base aux développements d'autres composants ou être utilisé directement dans une page (non conseillé).
-* - Applique la palette utilisateur
+* - Applique la palette utilisateur et le mode graphique (light/dark)
 * - Utilise le style de texte de l'application
 */
 export const ChartEcharts = forwardRef<EChartsReact, ChartEchartsProps>(({ option = {}, ...restProps }, ref) =>  { // devnote : A partir de React 19, ne plus utiliser forwardRef https://react.dev/reference/react/forwardRef

--- a/src/components/Control/Control.tsx
+++ b/src/components/Control/Control.tsx
@@ -135,7 +135,7 @@ export const ControlPreview:React.FC = ({}) => {
   const items:DescriptionsProps['items'] = Object.entries(controlValues).map(([key, value]) => ({
     key: key,
     label: key,
-    children: <p>{value}</p>,
+    children: <p>{JSON.stringify(value ?? '')}</p>,
   }));
 
   return (
@@ -147,7 +147,7 @@ export const ControlPreview:React.FC = ({}) => {
 
 type ControlContextType = {
     values : Record<string, any>;
-    register: (control: { name: string; value: any }) => void;
+    register: (control: Record<string, any>) => void;
     clear: () => void,
     getAll : () =>  Record<string, any>
 }
@@ -163,7 +163,7 @@ export const CreateControlesRegistry = () => {
       /* CONTROLS */
       const [controls, setControles] = useState<Record<string, any>>({});
       
-      const pushControl = useCallback( (c: Record<string, any>) => { 
+      const pushControl: ControlContextType['register'] = useCallback( (c) => { 
         setControles(prev => ({
             ...prev, 
             ...c

--- a/src/components/Control/Control.tsx
+++ b/src/components/Control/Control.tsx
@@ -38,7 +38,7 @@ export default Control;
 /*
  * Hook  pour accéder à un control spécifique de la page
  */
-export const useControl = (name: string): string | undefined => { 
+export const useControl = (name: string): any => { 
   const context_controls = useContext(ControlContext);
   if (!context_controls) {
     throw new Error("useControl must be used within a ControlProvider");

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -20,7 +20,7 @@ import { generateGradient } from './utils';
 import { theme } from 'antd';
 
 import {  jenks, quantileSorted } from 'simple-statistics';
-import { useHighlight } from '../../utils/useHighlight';
+import { useHighlight, useSetHighlight } from '../../utils/useHighlight';
 
 
 
@@ -84,6 +84,9 @@ export interface MapProps extends MapLayerProps {
   /** Zoom initial */
   zoom?: number;
 
+  /** Propriété à faire remonter lors du survol */
+  highlightProperty?: string
+
 }
 
 /** _Beta_ : Un composant permettant un affichage cartographique d'un jeu de données 
@@ -95,13 +98,14 @@ export interface MapProps extends MapLayerProps {
 */
 export const Map:React.FC<MapProps> = ({dataset, color, paint, categoryKey, interpolationMethod, nClasses, valueKey:valueKeyInput, labelKey,
         popup = false, popupFormatter:popupFormatterUser, 
-        title, xKey, yKey, unit,
+        title, xKey, yKey, unit, highlightProperty,
         latitude=0, longitude=0, zoom=0, fitToData}) => {
 
     const valueKey = valueKeyInput || categoryKey;
 
     const mapRef = useRef<MapRef>(null);
 
+    const sethilighted = useSetHighlight()
 
     const [clickedFeature, setClickedFeature] = useState<any>(undefined);
 
@@ -128,7 +132,13 @@ export const Map:React.FC<MapProps> = ({dataset, color, paint, categoryKey, inte
             </>
         ));
 
-    const onMouseMoveMap = (evt:any) => {
+
+    const onMouseMoveMap = (evt:any) => { // Attention, déclenché plusieurs dizaines de fois par seconde
+
+        if(highlightProperty) {
+            sethilighted({property:highlightProperty, value:evt.features[0]?.properties?.[highlightProperty]})
+        }
+
         if (!mapRef.current) {
             return
         }

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -147,7 +147,13 @@ export const Map:React.FC<MapProps> = ({dataset, color, paint, categoryKey, inte
         }else {
             mapRef.current.getCanvasContainer().style.cursor = 'grab'
         }
-  }
+    }
+
+    const onMouseLeave = () => {
+        if(highlightProperty) {
+            sethilighted({property:highlightProperty, value:null})
+        }
+    }
     
     const mapStyle = useMemo(() => ({
         version: 8 as const,
@@ -164,6 +170,7 @@ export const Map:React.FC<MapProps> = ({dataset, color, paint, categoryKey, inte
           interactiveLayerIds={['dataset']} 
           onClick={onClickMap}  
           onMouseMove={onMouseMoveMap}
+          onMouseLeave={onMouseLeave}
           initialViewState={{latitude:latitude, longitude:longitude, zoom:zoom}}
           mapStyle={mapStyle}
           style={{ width: '100%', height:'500px' }} 

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -132,11 +132,16 @@ export const Map:React.FC<MapProps> = ({dataset, color, paint, categoryKey, inte
             </>
         ));
 
+    const hoverTimeout = useRef<ReturnType<typeof setTimeout>>();
 
     const onMouseMoveMap = (evt:any) => { // Attention, déclenché plusieurs dizaines de fois par seconde
 
         if(highlightProperty) {
-            sethilighted({property:highlightProperty, value:evt.features[0]?.properties?.[highlightProperty]})
+            const value = evt.features?.[0]?.properties?.[highlightProperty];
+            clearTimeout(hoverTimeout.current);
+            hoverTimeout.current = setTimeout(() => {
+                sethilighted({property:highlightProperty, value:value})
+            },15)
         }
 
         if (!mapRef.current) {
@@ -151,6 +156,7 @@ export const Map:React.FC<MapProps> = ({dataset, color, paint, categoryKey, inte
 
     const onMouseLeave = () => {
         if(highlightProperty) {
+            clearTimeout(hoverTimeout.current);
             sethilighted({property:highlightProperty, value:null})
         }
     }

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -20,6 +20,7 @@ import { generateGradient } from './utils';
 import { theme } from 'antd';
 
 import {  jenks, quantileSorted } from 'simple-statistics';
+import { useHighlight } from '../../utils/useHighlight';
 
 
 
@@ -94,7 +95,6 @@ export interface MapProps extends MapLayerProps {
 */
 export const Map:React.FC<MapProps> = ({dataset, color, paint, categoryKey, interpolationMethod, nClasses, valueKey:valueKeyInput, labelKey,
         popup = false, popupFormatter:popupFormatterUser, 
-        highlightFeature,
         title, xKey, yKey, unit,
         latitude=0, longitude=0, zoom=0, fitToData}) => {
 
@@ -163,7 +163,7 @@ export const Map:React.FC<MapProps> = ({dataset, color, paint, categoryKey, inte
 
             <MapLayer 
                 dataset={dataset} fitToData={fitToData}
-                color={color} paint={paint} interpolationMethod={interpolationMethod} nClasses={nClasses} highlightFeature={highlightFeature}
+                color={color} paint={paint} interpolationMethod={interpolationMethod} nClasses={nClasses}
                 valueKey={valueKey} labelKey={labelKey} xKey={xKey} yKey={yKey} unit={unit} />
             
             { clickedFeature?.properties && popup &&
@@ -224,9 +224,6 @@ interface MapLayerProps {
     /** Centrer automatiquement la carte sur les données (true) */
     fitToData?: boolean;
 
-    /** Feature à mettre en surbrillance */
-    highlightFeature?: { property: string; value: string | number; };
-
     /** Couleur de subrillance */
     highlightColor?: string
 }
@@ -243,10 +240,12 @@ export const MapLayer:React.FC<MapLayerProps> = ({
         dataset, valueKey:valueKeyInput, categoryKey, labelKey,
         interpolationMethod='quantile', nClasses = 5, color, paint, 
         xKey, yKey, geomKey:geomKey_input, unit,
-        highlightFeature, highlightColor,
+        highlightColor,
         fitToData=true }) => {
 
     const {current: map} = useMap();
+
+    const hilightedFeature = useHighlight()
 
     const valueKey = valueKeyInput || categoryKey ;
     const data = useDataset(dataset)
@@ -381,11 +380,11 @@ export const MapLayer:React.FC<MapLayerProps> = ({
         layers.push(
             <Layer key={'dataset' + '_hightline'} id={'dataset' + '_hightline'} 
                 type='line' 
-                filter={ highlightFeature?.value ? 
+                filter={ hilightedFeature?.value ? 
                             [
                                 "==",
-                                ["get", highlightFeature.property ],
-                                highlightFeature.value,
+                                ["get", hilightedFeature.property ],
+                                hilightedFeature.value,
                             ]
                             : ["literal", false] //No hilight : filter all entities
                 }

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -418,6 +418,27 @@ export const MapLayer:React.FC<MapLayerProps> = ({
             />
         )
 
+        layers.push(
+            <Layer
+                key="dataset_highlight_mask"
+                id="dataset_highlight_mask"
+                type="fill"
+                filter={
+                    hilightedFeature?.value
+                        ? [
+                            "!=",
+                            ["get", hilightedFeature.property],
+                            hilightedFeature.value,
+                        ]
+                        : ["literal", false]
+                }
+                paint={{
+                    "fill-color": token.colorBgMask,
+                    "fill-opacity": 0.4,
+                }}
+            />
+        );
+
     } 
     /** LINESTRING */ 
     else if (geom_type === 'LineString' || geom_type === 'MultiLineString') {

--- a/src/components/Map/MapIndicator.tsx
+++ b/src/components/Map/MapIndicator.tsx
@@ -11,7 +11,7 @@ import { datasetInput } from "../Dataset/hooks"
 
 type GeoLevel = 'commune' | 'epci' | 'département'
 
-interface MapIndicatorProps extends Pick<MapProps, 'unit'> {
+interface MapIndicatorProps extends Pick<MapProps, 'highlightProperty' | 'unit'> {
     /** Jeu de données en entrée. Il doit contenir : 
      * - Un colonne "code_insee" (commune) ou "geocode_epci" (epci)
      * - Une colonne "valeur" numérique
@@ -36,6 +36,7 @@ export const MapIndicator:React.FC<MapIndicatorProps> = ({
     nClasses=4, 
     color, 
     unit,
+    highlightProperty,
     dataLevel='auto'}) => {
 
     const [level, setLevel] = useState<GeoLevel>( dataLevel === 'auto' ? 'commune' : dataLevel)
@@ -132,6 +133,7 @@ export const MapIndicator:React.FC<MapIndicatorProps> = ({
             dataset={level == 'commune' ? joined : level == 'epci' ? agg_epci : agg_dep} 
             valueKey="valeur" 
             unit={unit}
+            highlightProperty={highlightProperty}
             interpolationMethod={interpolationMethod} 
             nClasses={nClasses} 
             color={color}

--- a/src/components/Map/MapIndicator.tsx
+++ b/src/components/Map/MapIndicator.tsx
@@ -11,7 +11,7 @@ import { datasetInput } from "../Dataset/hooks"
 
 type GeoLevel = 'commune' | 'epci' | 'département'
 
-interface MapIndicatorProps extends Pick<MapProps, 'highlightFeature' | 'unit'> {
+interface MapIndicatorProps extends Pick<MapProps, 'unit'> {
     /** Jeu de données en entrée. Il doit contenir : 
      * - Un colonne "code_insee" (commune) ou "geocode_epci" (epci)
      * - Une colonne "valeur" numérique
@@ -36,7 +36,6 @@ export const MapIndicator:React.FC<MapIndicatorProps> = ({
     nClasses=4, 
     color, 
     unit,
-    highlightFeature: highlight,
     dataLevel='auto'}) => {
 
     const [level, setLevel] = useState<GeoLevel>( dataLevel === 'auto' ? 'commune' : dataLevel)
@@ -136,7 +135,6 @@ export const MapIndicator:React.FC<MapIndicatorProps> = ({
             interpolationMethod={interpolationMethod} 
             nClasses={nClasses} 
             color={color}
-            highlightFeature={highlight}
             popup/>
         </div>
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { useChartExport  } from "./utils/usechartexports";
 export { useApi } from "./utils/useApi";
 export { useChartData, useDashboardElement, useNoData } from "./components/DashboardElement/hooks";
 export { useMapControl } from "./utils/useMapControl";
+export { useHighlight, useSetHighlight} from "./utils/useHighlight"
 
 // Helpers
 export { BaseRecordToGeojsonPoint } from "./utils/baserecordtogeojsonpoint"

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export { useChartExport  } from "./utils/usechartexports";
 export { useApi } from "./utils/useApi";
 export { useChartData, useDashboardElement, useNoData } from "./components/DashboardElement/hooks";
 export { useMapControl } from "./utils/useMapControl";
-export { useHighlight, useSetHighlight} from "./utils/useHighlight"
+export { useHighlight, useSetHighlight, useApplyEchartsHighlight} from "./utils/useHighlight"
 
 // Helpers
 export { BaseRecordToGeojsonPoint } from "./utils/baserecordtogeojsonpoint"

--- a/src/utils/useHighlight.ts
+++ b/src/utils/useHighlight.ts
@@ -75,13 +75,14 @@ export const useApplyEchartsHighlight = ({chartRef, name}: useApplyEchartsHighli
     const echartsInstance = chartRef.current?.getEchartsInstance()
     try { // Non critique, ca ne doit pas faire crasher l'application
 
+        //Release existing highlight
+        echartsInstance?.dispatchAction({type:"downplay"})
+
         highlighted?.value && echartsInstance?.dispatchAction({
             type: 'highlight',
             name: highlighted.value,
         })
 
-        //Release highlight
-        highlighted?.value == null && echartsInstance?.dispatchAction({type:"downplay"})
     }
     catch(error) {
         console.warn('Impossible d’appliquer le highlight ECharts', error);

--- a/src/utils/useHighlight.ts
+++ b/src/utils/useHighlight.ts
@@ -3,7 +3,7 @@
  * le nom de la propriété et la valeur de l'entité à surbriller
  */
 
-import { useCallback, useContext } from "react"
+import { useCallback, useContext, useRef } from "react"
 import { ControlContext } from "../components/Control/Control"
 import EChartsReact from "echarts-for-react";
 
@@ -27,11 +27,23 @@ export const useHighlight = ():feature_filter => {
 /** Définir une entité à surbriller */
 export const useSetHighlight = () => {
 
+    const lastHighlight = useRef<feature_filter>();
+
   // On utilise le mécanisme des contrôles. Il s'agit d'un contrôle
   // caché nommé 'highlight'
   const controlesRegistry = useContext(ControlContext); 
 
   return useCallback((f: feature_filter) => {
+
+    //Avoid unnecessary rerender
+    if (
+      lastHighlight.current?.property === f.property &&
+      lastHighlight.current?.value === f.value
+    ) {
+      return;
+    }
+
+    lastHighlight.current = f;
     controlesRegistry?.register({ highlight : f });
   }, [controlesRegistry]);
 };

--- a/src/utils/useHighlight.ts
+++ b/src/utils/useHighlight.ts
@@ -1,0 +1,28 @@
+/** Hook permettant de partager une feature en surbrillance 
+ * On utilise le mécanisme des controles pour partager un objet contenant
+ * le nom de la propriété et la valeur de l'entité à surbriller
+ */
+
+import { useContext } from "react"
+import { ControlContext, useControl } from "../components/Control/Control"
+
+interface feature_filter {
+    property: string,
+    value?: any
+}
+
+export const useHighlight = ():feature_filter => {
+    const f = useControl('highligt') as feature_filter
+    return f
+}
+
+
+
+
+/** Définir une entité à surbriller */
+export const useSetHighlight = (f:feature_filter) => {
+
+    const controlesRegistry = useContext(ControlContext)
+    controlesRegistry?.register( {name: 'highligt', value: f } )
+
+}

--- a/src/utils/useHighlight.ts
+++ b/src/utils/useHighlight.ts
@@ -11,14 +11,13 @@ interface feature_filter {
     value: any | null
 }
 
+
+/** Récupérer l'entité à surbriller */
 export const useHighlight = ():feature_filter => {
-   // const f = useControl('highlight') as feature_filter
 
     const controlesRegistry = useContext(ControlContext);
 
-    const f = controlesRegistry?.values.highlight
-    console.log('geted feature', controlesRegistry?.values)
-    return f
+    return controlesRegistry?.values.highlight
 }
 
 
@@ -26,10 +25,12 @@ export const useHighlight = ():feature_filter => {
 
 /** Définir une entité à surbriller */
 export const useSetHighlight = () => {
-  const controlesRegistry = useContext(ControlContext);
+
+  // On utilise le mécanisme des contrôles. Il s'agit d'un contrôle
+  // caché nommé 'highlight'
+  const controlesRegistry = useContext(ControlContext); 
 
   return useCallback((f: feature_filter) => {
-    console.log('registerd value', f)
     controlesRegistry?.register({ highlight : f });
   }, [controlesRegistry]);
 };

--- a/src/utils/useHighlight.ts
+++ b/src/utils/useHighlight.ts
@@ -3,16 +3,21 @@
  * le nom de la propriété et la valeur de l'entité à surbriller
  */
 
-import { useContext } from "react"
-import { ControlContext, useControl } from "../components/Control/Control"
+import { useCallback, useContext } from "react"
+import { ControlContext } from "../components/Control/Control"
 
 interface feature_filter {
     property: string,
-    value?: any
+    value: any | null
 }
 
 export const useHighlight = ():feature_filter => {
-    const f = useControl('highligt') as feature_filter
+   // const f = useControl('highlight') as feature_filter
+
+    const controlesRegistry = useContext(ControlContext);
+
+    const f = controlesRegistry?.values.highlight
+    console.log('geted feature', controlesRegistry?.values)
     return f
 }
 
@@ -20,9 +25,11 @@ export const useHighlight = ():feature_filter => {
 
 
 /** Définir une entité à surbriller */
-export const useSetHighlight = (f:feature_filter) => {
+export const useSetHighlight = () => {
+  const controlesRegistry = useContext(ControlContext);
 
-    const controlesRegistry = useContext(ControlContext)
-    controlesRegistry?.register( {name: 'highligt', value: f } )
-
-}
+  return useCallback((f: feature_filter) => {
+    console.log('registerd value', f)
+    controlesRegistry?.register({ highlight : f });
+  }, [controlesRegistry]);
+};

--- a/src/utils/useHighlight.ts
+++ b/src/utils/useHighlight.ts
@@ -5,6 +5,7 @@
 
 import { useCallback, useContext } from "react"
 import { ControlContext } from "../components/Control/Control"
+import EChartsReact from "echarts-for-react";
 
 interface feature_filter {
     property: string,
@@ -34,3 +35,43 @@ export const useSetHighlight = () => {
     controlesRegistry?.register({ highlight : f });
   }, [controlesRegistry]);
 };
+
+
+
+interface useApplyEchartsHighlightProps {
+    /** Référence du graphique */
+    chartRef: React.RefObject<EChartsReact>,
+
+    /** Définir manuellement un dataname à mettre en surbrillance (défaut : auto) */
+    name?: string
+}
+
+/** Hook helper permettant d'appliquer une surbrillance sur un élement d'un graphique Echarts
+ * La surbrillance se base sur le nom des itemps Echarts. Le nom peut être définie soit :
+ * - Avec encode (https://echarts.apache.org/en/option.html#series-line.encode)
+ * - En définissant les données comme {name:'a', values:[5, 'b']}
+ * @experimental
+*/
+export const useApplyEchartsHighlight = ({chartRef, name}: useApplyEchartsHighlightProps) => {
+
+    //devnote : traiter ici aussi les remontées de surbrillance ? (a partir des event du charts)
+
+    const auto_highlighted = useHighlight();
+
+    const highlighted = name ? {value:name} : auto_highlighted;
+
+    const echartsInstance = chartRef.current?.getEchartsInstance()
+    try { // Non critique, ca ne doit pas faire crasher l'application
+
+        highlighted?.value && echartsInstance?.dispatchAction({
+            type: 'highlight',
+            name: highlighted.value,
+        })
+
+        //Release highlight
+        highlighted?.value == null && echartsInstance?.dispatchAction({type:"downplay"})
+    }
+    catch(error) {
+        console.warn('Impossible d’appliquer le highlight ECharts', error);
+    }
+}

--- a/src/utils/usecharthightlight.ts
+++ b/src/utils/usecharthightlight.ts
@@ -55,7 +55,9 @@ export interface useChartActionProps{ //TODO : remplacer highlight_key et item p
   }
 
 /** Hook permettant de highlight un élément d'un graphique ECharts 
+ * Deprécier, voir useApplyEchartsHighlight
  * @category Hook
+ * @deprecated
 */
 export const useChartActionHightlight = ({chartRef, target}:useChartActionProps) => {
  

--- a/stories-docs/CreateComponent.mdx
+++ b/stories-docs/CreateComponent.mdx
@@ -13,7 +13,55 @@ import { Meta } from '@storybook/addon-docs/blocks';
 - `useThemeContext().resolvedMode` : mode appliqué (`dark` ou `light`).
 - `useDataset` 
 - `useBlockConfig` : configurer le contenant du graphique (titre et données disponibles dans le menu contextuel)
+- `useHighlight` et `useSetHighlight`  : utiliser et définir les entités à surbriller
 
+
+## Surbrillance (Highlight)
+
+Votre graphique ou carte peut mettre en avant certaines entités.
+Le cas d'usage général est le suivant : au survol d'un élément sur une dataviz, on souhaite mettre 
+en avant le même élément sur une autre dataviz de la page.
+
+Votre graphique a donc la possibilité : 
+- d'indiquer aux autres composants qu'il souhaite surbriller un élement (par exemple si l'utilisateur le clique ou survol)
+- inversement, de savoir si un autre composant souhaite surbriller un objet
+
+Pour définir un objet (série, entité cartographique, point...) on utilise un filtre de type `{property: '<nomDeLaColonne>', value:'<valeur>'}`.
+
+
+
+```tsx 
+
+/* 
+Dans cet exemple, lorsque l'utilisateur survol un élément de graphique, 
+on utilise une valeur pour (ici la dimension Y, cf https://echarts.apache.org/en/option.html#series-bar.data ) 
+pour surbriller d'autres composant de la page
+*/
+
+export const MyDataviz:React.FC<MyDatavizProps> = () => {
+
+    // ....
+
+    const onHover = (e:any) => {
+        if(e.componentType == "series"){
+            // A adapter en fonction du jeu de données et du graphique, il s'agit de l'attribut qu'on souhaite utilier pour la surbrillance
+            setHighlight({property:'geocode_epci', value:e.data[1]}) 
+        }
+    }
+
+    // Ne pas oublier de retirer la surbrillance quand la souris quitte l'objet !
+    const onOut = () => {
+        setHighlight({property:'geocode_epci', value:null})
+    };
+
+
+    return <ChartEcharts option={option} onEvents={{mouseover:onHover, mouseOut:onOut}} />
+
+}
+
+
+// TODO : a compléter avec un "recepteur" de surbrillance
+```
 
 ## À partir d'un graphique api-dashboard
 

--- a/stories-docs/CreateComponent.mdx
+++ b/stories-docs/CreateComponent.mdx
@@ -5,6 +5,16 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Créer son composant graphique
 
+🚧 Page en cours de rédaction.
+
+## Fonctions et hook utiles  : 
+
+- `usePalette` : récupérer les couleurs de la page
+- `useThemeContext().resolvedMode` : mode appliqué (`dark` ou `light`).
+- `useDataset` 
+- `useBlockConfig` : configurer le contenant du graphique (titre et données disponibles dans le menu contextuel)
+
+
 ## À partir d'un graphique api-dashboard
 
 Partir d'un graphique générique et personnaliser les propriétés.
@@ -17,10 +27,10 @@ Modèle pour créer un composant ECharts :
 ```tsx
 import { ChartEcharts, useBlockConfig, useDataset } from "@geo2france/api-dashboard/dsl"
 import { EChartsOption } from "echarts"
-import { datasetInput } from "@geo2france/api-dashboard"
+import { datasetInput, BaseChartProps } from "@geo2france/api-dashboard"
 
 
-export interface MyDatavizProps {
+export interface MyDatavizProps extends BaseChartsProps {
     /** Jeu de données */
     dataset: datasetInput
 


### PR DESCRIPTION
L'objectif de cette PR est de faciliter la conception de tableaux de bords plus agréables pour l'utilisateur avec des effets de _cross-highlighting_.

Ajout de hook pour faciliter le partage de surbrillance.
Chaque graphique peut faire remonter une demande de surbrillance au niveau de la page. Cette demande est un objet `{property:'<NomDeLaProp>', value:'<Valeur>'}`

- `useSetHighlight()` : récupérer une fonction qui permet de remonter un objet à surbriller
- `useHighlight()`: objet à surbriller

Un hook **expérimental** est ajouté `useApplyEchartsHighlight()`. Il permet d'appliquer automatiquement une surbrillance à un graphique ECharts. Nécessite que les items soit nommées dans Echarts (à l'aide de [_encode_](https://echarts.apache.org/en/option.html#series-bar.encode.itemName) ou directement dans [_data_](https://echarts.apache.org/en/option.html#series-bar.data.name) ).
En utilisant les deux hook précédent, cette fonctionnalité peut toutefois être utilisée sur n'importe quelle dataviz _custom_ utilisant une autre bibliothèque que Echarts.

Pour les cartes `<Map>`, la surbrillance est appliquée si la couche contient un objet avec la propriété et la valeur correspondante. La propriété optionnelle `HighlightProperty` permet d'indiquer à la carte la propriété à faire remonter pour une demande de surbrillance à la page (en général l'identifiant d'un territoire).

<img width="632" height="347" alt="image" src="https://github.com/user-attachments/assets/43a540e2-b2ca-4424-b500-b76b21f3b28c" />
